### PR TITLE
Enable font antialiasing.

### DIFF
--- a/src/com/superliminal/magiccube4d/MC4DSwing.java
+++ b/src/com/superliminal/magiccube4d/MC4DSwing.java
@@ -1596,12 +1596,8 @@ public class MC4DSwing extends JFrame {
             public void run() {
                 System.out.println("version " + System.getProperty("java.version"));
                 PropertyManager.loadProps(args, PropertyManager.top);
-                try {
-                    UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-                }
-                catch(Exception e) {
-                    e.printStackTrace();
-                }
+                trySetLookAndFeel();
+
                 final JFrame frame = new MC4DSwing();
                 configureNormal(frame);
                 frame.addComponentListener(new ComponentAdapter() {
@@ -1634,6 +1630,21 @@ public class MC4DSwing extends JFrame {
                 });
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.setVisible(true);
+            }
+
+            void trySetLookAndFeel() {
+                // First set some properties to enable font antialiasing
+                // (copied from https://batsov.com/articles/2010/02/26/enable-aa-in-swing/).
+                // Note: this needs to happen before the call to `setLookAndFeel` below
+                System.setProperty("awt.useSystemAAFontSettings","on");
+                System.setProperty("swing.aatext", "true");
+
+                try {
+                    UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+                }
+                catch(Exception e) {
+                    e.printStackTrace();
+                }
             }
 
             void configureNormal(Frame frame) {


### PR DESCRIPTION
I found these instructions on
https://batsov.com/articles/2010/02/26/enable-aa-in-swing/. With this
change, things look *much* better for me on Arch Linux. I only need the
`awt.useSystemAAFontSettings` property for things to work for me, but
I guess I'll leave the `swing.aatext` around as well just in case?

## Before

![image](https://user-images.githubusercontent.com/277474/95822663-3289d200-0ce1-11eb-9d4b-ba1b45287f0c.png)

## After

![image](https://user-images.githubusercontent.com/277474/95822696-40d7ee00-0ce1-11eb-94cc-1d63e0ef6a50.png)
