### PR TITLE
Make colours from facecolors.txt be loaded upon puzzle creation

### DIFF
--- a/src/com/superliminal/magiccube4d/MC4DSwing.java
+++ b/src/com/superliminal/magiccube4d/MC4DSwing.java
@@ -1031,11 +1031,6 @@ public class MC4DSwing extends JFrame {
                 progressBar.setVisible(false);
                 hist.clear((int) puzzleManager.puzzleDescription.getEdgeLength());
                 updateTwistsLabel();
-                Color[] userColors = findColors(
-                    puzzleManager.puzzleDescription.getSchlafliProduct(),
-                    puzzleManager.puzzleDescription.nFaces());
-                if(userColors != null)
-                    puzzleManager.faceColors = userColors;
                 if(view != null)
                     view.repaint();
             }
@@ -1565,7 +1560,7 @@ public class MC4DSwing extends JFrame {
         return "facecolors" + File.separator + schlafli + ".txt";
     }
 
-    private static Color[] findColors(String schlafli, int len)
+    public static Color[] findColors(String schlafli, int len)
     {
         String filename = colorFilename(schlafli);
         Color[] colors = findColors(len, filename);

--- a/src/com/superliminal/magiccube4d/PuzzleManager.java
+++ b/src/com/superliminal/magiccube4d/PuzzleManager.java
@@ -118,7 +118,13 @@ public class PuzzleManager
                 if(newPuzzle != null) {
                     succeeded = true;
                     puzzleDescription = newPuzzle;
-                    faceColors = ColorUtils.generateVisuallyDistinctColors(puzzleDescription.nFaces(), .7f, .1f);
+                    Color[] userColors = MC4DSwing.findColors(
+                        puzzleDescription.getSchlafliProduct(),
+                        puzzleDescription.nFaces());
+                    if(userColors != null)
+                        faceColors = userColors;
+                    else
+                    	faceColors = ColorUtils.generateVisuallyDistinctColors(puzzleDescription.nFaces(), .7f, .1f);
                     resetPuzzleStateNoEvent();
                 }
                 return null;

--- a/src/com/superliminal/magiccube4d/PuzzleManager.java
+++ b/src/com/superliminal/magiccube4d/PuzzleManager.java
@@ -124,7 +124,7 @@ public class PuzzleManager
                     if(userColors != null)
                         faceColors = userColors;
                     else
-                    	faceColors = ColorUtils.generateVisuallyDistinctColors(puzzleDescription.nFaces(), .7f, .1f);
+                        faceColors = ColorUtils.generateVisuallyDistinctColors(puzzleDescription.nFaces(), .7f, .1f);
                     resetPuzzleStateNoEvent();
                 }
                 return null;


### PR DESCRIPTION
This solves the issue of the `facecolors.txt` file not being detected and loaded in unless the puzzle is changed or a log file is loaded. (Referenced by Issues #95 and #129) This problem was caused by the code for loading in the colours, namely the `findColors(schlafi, len)` method, which was only called in the `PuzzleListener` of the `PuzzleManager` object created. This directly caused the issue described above. To remedy this, I've simply transferred this call to `findColors`, as well as some additional logic handling the result, to a more appropriate location. The location I chose was the `initPuzzle` method of the `PuzzleManager` class. I also adapted the logic slightly to fall back on the preexisting default call of `generateVisuallyDistinctColors` in the case the `facecolors.txt` file did not yield appropriate or correct colours. To facilitate this, I changed the scope of the `findColors` method from `private` to `public`,