### PR TITLE
Remove Number Scramble Hotkeys

### DIFF
--- a/src/com/superliminal/magiccube4d/MC4DSwing.java
+++ b/src/com/superliminal/magiccube4d/MC4DSwing.java
@@ -887,7 +887,8 @@ public class MC4DSwing extends JFrame {
         for(int i = 1; i <= 8; i++) {
             scrambler = new Scrambler(i);
             scrambleItem = new JMenuItem("" + i);
-            StaticUtils.addHotKey(KeyEvent.VK_0 + i, scrambleItem, "Scramble" + i, scrambler);
+            // no hotkey
+            scrambleItem.addActionListener(scrambler);
             scramblemenu.add(scrambleItem);
         }
         scramblemenu.addSeparator();


### PR DESCRIPTION
Change the short scrambles to be menu items only, to prevent accidental scrambles while pressing undo/redo and a slice mask. (Has happened to me on several occasions, and to others, causing entire solve loss)